### PR TITLE
Added ability to specify sheet ID and tab ID via URL hash fragments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ src/*.js
 node_modules
 *.key
 package-lock.json
+dist

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@
 * `npm install -g typescript`
 * `tsc`
 * webpack stuff:
-  * `npm install typescript ts-loader webpack`
-  * `./node_modules/webpack/bin/webpack.js`
+  * `npm install typescript ts-loader webpack webpack-cli`
+  * `tsc && ./node_modules/webpack/bin/webpack.js`
 
 ## Usage
 

--- a/index.html
+++ b/index.html
@@ -13,12 +13,11 @@
         const data = sheet.result.values;
         const html = giantt.renderHTML(data);
         document.getElementById('authbox').style.display = 'none';
-        document.getElementById('contents').innerHTML = html;
+        document.write(html);
       }
     </script>
   </head>
   <body>
-    <div id='contents'></div>
     <div id='authbox'>
       <p>Arcs Gantt Chart</p>
 

--- a/index.html
+++ b/index.html
@@ -6,9 +6,20 @@
     <script src="./dist/bundle.js"></script>
     <script type="text/javascript">
       async function doTheThing() {
+        const DEFAULT_SHEET_ID = '1L1g-Bk7Vx_QJmOZehRHetbWT4uziaIRa3L2U-VrrGU0';
+        const DEFAULT_TAB_ID = 'giantt';
+
+        // Pull the sheet and tab ID out of the URL's hash fragment (or just
+        // use defaults). Values can be supplied like so:
+        // http://path.to.page#sheetId=asdf&tabId=ghjk
+        const hash = location.hash ? location.hash.substr(1) : '';
+        const params = new URLSearchParams(hash);
+        const sheetId = params.get('sheetId') || DEFAULT_SHEET_ID;
+        const tabId = params.get('tabId') || DEFAULT_TAB_ID;
+
         const sheet = await gapi.client.sheets.spreadsheets.values.get({
-          spreadsheetId: '1L1g-Bk7Vx_QJmOZehRHetbWT4uziaIRa3L2U-VrrGU0',
-          range: 'giantt',
+          spreadsheetId: sheetId,
+          range: tabId,
         });
         const data = sheet.result.values;
         const html = giantt.renderHTML(data);


### PR DESCRIPTION
e.g.

`#sheetId=1QON1NOSbl0AyF-1SgG2yHvcW0J40-CrR1aMOl69doOE&tabId=asdf`